### PR TITLE
Add m2e-wtp 0.16.0 (from eclipse.org) 

### DIFF
--- a/org.eclipse.m2e.discovery.oss/connectors.xml
+++ b/org.eclipse.m2e.discovery.oss/connectors.xml
@@ -238,13 +238,13 @@
     <!-- https://bugs.eclipse.org/bugs/show_bug.cgi?id=353361 -->
     <catalogItem>
       <categoryId>org.eclipse.m2e.discovery.category.lifecycles</categoryId>
-      <m2e-versions>1.0,1.1</m2e-versions>
-      <description>m2e-wtp</description>
+      <m2e-versions>1.0</m2e-versions>
+      <description>m2eclipse-wtp</description>
       <groupId>lifecycles</groupId>
-      <id>org.eclipse.m2e.discovery.lifecyclemapping.m2e-wtp</id>
+      <id>org.eclipse.m2e.discovery.lifecyclemapping.m2eclipse-wtp</id>
       <kind>lifecycles</kind>
       <license>EPL</license>
-      <name>m2e-wtp</name>
+      <name>m2eclipse-wtp</name>
       <provider>JBoss by Red Hat</provider>
       <p2>
         <repositoryUrl>http://download.jboss.org/jbosstools/updates/m2eclipse-wtp/</repositoryUrl>
@@ -257,6 +257,33 @@
       <overview>
         <summary>Maven Integration for WTP</summary>
         <url>https://github.com/sonatype/m2eclipse-wtp</url>
+      </overview>
+    </catalogItem>
+     
+    <catalogItem>
+      <categoryId>org.eclipse.m2e.discovery.category.lifecycles</categoryId>
+      <m2e-versions>1.1</m2e-versions>
+      <description>m2e-wtp provides a set of connectors used for the configuration of Java EE projects in WTP</description>
+      <groupId>lifecycles</groupId>
+      <id>org.eclipse.m2e.discovery.lifecyclemapping.m2e-wtp</id>
+      <kind>lifecycles</kind>
+      <license>EPL</license>
+      <name>m2e-wtp : Maven Integration for WTP (Incubation)</name>
+      <provider>Eclipse.org</provider>
+      <p2>
+        <repositoryUrl>http://download.eclipse.org/m2e-wtp/releases/</repositoryUrl>
+        <iuId>org.eclipse.m2e.wtp.feature.feature.group</iuId>
+        <iuVersion>0.16.0.20120914-0945</iuVersion>
+        <lifecycleMappingIU>
+          <iuId>org.eclipse.m2e.wtp</iuId>
+        </lifecycleMappingIU>
+      </p2>
+      <overview>
+        <summary>Maven Integration for Eclipse WTP (a.k.a m2e-wtp) aims at providing a tight integration between Maven Integration for Eclipse (a.k.a m2e) and the Eclipse Web Tools Project (WTP).
+m2e-wtp provides a set of m2e connectors used for the configuration of Java EE projects in WTP.
+m2e-wtp also brings some advanced Maven features to the Eclipse environment such as overlays of workspace project and .war archives dependencies and on-the-fly resource filtering.
+Finally, m2e-wtp helps you convert your legacy Eclipse projects to Maven, by translating your Java EE eclipse project settings into maven plugin configuration.</summary>
+        <url>https://www.eclipse.org/m2e-wtp/</url>
       </overview>
     </catalogItem>
 


### PR DESCRIPTION
Add m2e-wtp 0.16.0 (from eclipse.org)  for m2e 1.1.

m2eclipse-wtp 0.15.3 is defined for m2e 1.0 only.

Signed-off-by: Fred Bricon fbricon@gmail.com
