### PR TITLE
Pick up newer release of the checkstyle and pmd connectors to enable 1.2.

### DIFF
--- a/org.eclipse.m2e.discovery.oss/src/main/resources-filtered/connectors.xml
+++ b/org.eclipse.m2e.discovery.oss/src/main/resources-filtered/connectors.xml
@@ -396,7 +396,7 @@ Finally, m2e-wtp helps you convert your legacy Eclipse projects to Maven, by tra
       <p2>
         <repositoryUrl>http://m2e-code-quality.github.com/m2e-code-quality/site/1.0/</repositoryUrl>
         <iuId>com.basistech.m2e.code.quality.checkstyle.feature.feature.group</iuId>
-        <iuVersion>1.0.0.201209141747</iuVersion>
+        <iuVersion>1.0.0.201211052156</iuVersion>
         <lifecycleMappingIU>
           <iuId>com.basistech.m2e.code.quality.checkstyle</iuId>
         </lifecycleMappingIU>
@@ -420,7 +420,7 @@ Finally, m2e-wtp helps you convert your legacy Eclipse projects to Maven, by tra
       <p2>
         <repositoryUrl>http://m2e-code-quality.github.com/m2e-code-quality/site/1.0/</repositoryUrl>
         <iuId>com.basistech.m2e.code.quality.pmd.feature.feature.group</iuId>
-        <iuVersion>1.0.0.201209141747</iuVersion>
+        <iuVersion>1.0.0.201211052156</iuVersion>
         <lifecycleMappingIU>
           <iuId>com.basistech.m2e.code.quality.pmd</iuId>
         </lifecycleMappingIU>


### PR DESCRIPTION
I pushed a new release of the cs and pmd connectors in the old-fashioned gh-pages mechanism, and updates the iuVersion elements, and here it is, and it appears to work with 1.2.
