### PR TITLE
adding connector for scala (ScalaIDE, scala-maven-plugin)

### DIFF
--- a/org.eclipse.m2e.discovery.oss/src/main/resources-filtered/connectors.xml
+++ b/org.eclipse.m2e.discovery.oss/src/main/resources-filtered/connectors.xml
@@ -1046,5 +1046,27 @@ http://objectledge.org/confluence/display/TOOLS/ckpackager-maven-plugin
         </overview>
     </catalogItem>
 
+    <catalogItem>
+      <categoryId>org.eclipse.m2e.discovery.category.lifecycles</categoryId>
+      <description>Maven Integration for Scala IDE and the scala-maven-plugin</description>
+      <groupId>lifecycles</groupId>
+      <id>org.sonatype.m2e.discovery.publisher.maven-plugin</id>
+      <kind>lifecycles</kind>
+      <license>EPL</license>
+      <name>m2e connector for scala-maven-plugin</name>
+      <provider>Sonatype, Inc. - David Bernard</provider>
+      <p2>
+        <repositoryUrl>http://alchim31.free.fr/m2e-scala/update-site/m2eclipse-scala/</repositoryUrl>
+        <iuId>org.maven.ide.eclipse.scala_feature.feature.group</iuId>
+        <lifecycleMappingIU>
+          <iuId>org.maven.ide.eclipse.scala</iuId>
+        </lifecycleMappingIU>
+      </p2>
+      <overview>
+        <summary>Provides the lifecycle mapping for scala-maven-plugin</summary>
+        <url>https://github.com/sonatype/m2eclipse-scala</url>
+      </overview>
+    </catalogItem>
+
   </catalogItems>
 </catalog>


### PR DESCRIPTION
I can't test the integration  : 

```
➜  m2e-discovery-catalog git:(master) ✗ mvn clean package
[INFO] Scanning for projects...
[WARNING] The POM for org.sonatype.plugins:maven-tinkerbell-plugin:jar:0.0.1-SNAPSHOT is missing, no dependency information available
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project org.eclipse.m2e:org.eclipse.m2e.discovery.oss:1.0.0-SNAPSHOT (/home/dwayne/work/oss/m2e-discovery-catalog/org.eclipse.m2e.discovery.oss/pom.xml) has 2 errors
[ERROR]     Unresolveable build extension: Plugin org.sonatype.plugins:maven-tinkerbell-plugin:0.0.1-SNAPSHOT or one of its dependencies could not be resolved: Failure to find org.sonatype.plugins:maven-tinkerbell-plugin:jar:0.0.1-SNAPSHOT in http://repository.tesla.io:8081/nexus/content/repositories/snapshots/ was cached in the local repository, resolution will not be reattempted until the update interval of tesla-snapshots has elapsed or updates are forced -> [Help 2]
[ERROR]     Unknown packaging: null @ line 12, column 14
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/PluginResolutionException
```

Thanks
