### PR TITLE
Fix missing m2e-ajdt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .project
 .classpath
 target/
+.DS_Store

--- a/org.eclipse.m2e.discovery.oss/src/main/resources-filtered/connectors.xml
+++ b/org.eclipse.m2e.discovery.oss/src/main/resources-filtered/connectors.xml
@@ -781,6 +781,7 @@ http://objectledge.org/confluence/display/TOOLS/ckpackager-maven-plugin
     <catalogItem>
       <categoryId>org.eclipse.m2e.discovery.category.lifecycles</categoryId>
       <description>AspectJ m2e configurator</description>
+      <m2e-versions>1.3,1.4,1.5</m2e-versions>
       <groupId>lifecycles</groupId>
       <id>org.maven.ide.eclipse.ajdt</id>
       <kind>lifecycles</kind>
@@ -790,7 +791,7 @@ http://objectledge.org/confluence/display/TOOLS/ckpackager-maven-plugin
       <p2>
         <repositoryUrl>http://dist.springsource.org/release/AJDT/composite/</repositoryUrl>
         <iuId>org.maven.ide.eclipse.ajdt.feature.feature.group</iuId>
-        <iuVersion>0.14.0.201301311331</iuVersion>
+        <iuVersion>0.14.0.201302011330</iuVersion>
         <lifecycleMappingIU>
           <iuId>org.maven.ide.eclipse.ajdt</iuId>
         </lifecycleMappingIU>

--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,9 @@
   </modules>
 
   <properties>
-    <tycho-version>0.19.0</tycho-version>
+    <tycho-version>0.21.0</tycho-version>
 
-    <m2e-core.url>http://download.eclipse.org/technology/m2e/releases/1.4</m2e-core.url>
+    <m2e-core.url>http://download.eclipse.org/technology/m2e/releases/1.5</m2e-core.url>
   </properties>
 
   <build>


### PR DESCRIPTION
Fix m2e-ajdt not being accessible in the m2e 1.5 discovery catalog anymore

Signed-off-by: Fred Bricon fbricon@gmail.com
