### PR TITLE
Updated m2e-android with new ADT plugin IDs.

### DIFF
--- a/org.eclipse.m2e.discovery.oss/src/main/resources-filtered/connectors.xml
+++ b/org.eclipse.m2e.discovery.oss/src/main/resources-filtered/connectors.xml
@@ -739,13 +739,13 @@ http://objectledge.org/confluence/display/TOOLS/ckpackager-maven-plugin
           <iuId>me.gladwell.eclipse.m2e.android</iuId>
         </lifecycleMappingIU>
         <rootIU>
-          <iuId>com.android.ide.eclipse.adt.feature.group</iuId>
+          <iuId>com.android.ide.eclipse.adt.feature.feature.group</iuId>
         </rootIU>
         <rootIU>
-          <iuId>com.android.ide.eclipse.ddms.feature.group</iuId>
+          <iuId>com.android.ide.eclipse.ddms.feature.feature.group</iuId>
         </rootIU>
         <rootIU>
-          <iuId>com.android.ide.eclipse.traceview.feature.group</iuId>
+          <iuId>com.android.ide.eclipse.traceview.feature.feature.group</iuId>
         </rootIU>
       </p2>
       <overview>


### PR DESCRIPTION
This was breaking m2e discovery installation of the m2e-android plugin.
