### PR TITLE
Added Subversive 3.0+ m2e connector

### DIFF
--- a/org.eclipse.m2e.discovery.oss/src/main/resources-filtered/connectors.xml
+++ b/org.eclipse.m2e.discovery.oss/src/main/resources-filtered/connectors.xml
@@ -290,7 +290,7 @@ Finally, m2e-wtp helps you convert your legacy Eclipse projects to Maven, by tra
         <groupId>extras</groupId>
         <id>org.eclipse.m2e.discovery.lifecyclemapping.m2e-subversive</id>
         <kind>extras</kind>
-        <license>Eclipse Public License - v1.0</license>
+        <license>EPL</license>
         <name>m2e-subversive</name>
         <provider>Eclipse.org</provider>
         <p2>
@@ -298,7 +298,7 @@ Finally, m2e-wtp helps you convert your legacy Eclipse projects to Maven, by tra
             <iuId>org.eclipse.team.svn.m2e.feature.group</iuId>
       </p2>
       <overview>
-        <summary>Integration with M2E http://www.eclipse.org/m2e Installation is possible only if M2E is already installed or installed in one step with Eclipse Subversive.</summary>
+        <summary>Maven SCM Handler for Subversive</summary>
         <url>http://www.eclipse.org/subversive/</url>
       </overview>
     </catalogItem>

--- a/org.eclipse.m2e.discovery.oss/src/main/resources-filtered/connectors.xml
+++ b/org.eclipse.m2e.discovery.oss/src/main/resources-filtered/connectors.xml
@@ -282,6 +282,26 @@ Finally, m2e-wtp helps you convert your legacy Eclipse projects to Maven, by tra
         <url>https://github.com/tesla/m2eclipse-subversive</url>
       </overview>
     </catalogItem>
+    
+    <catalogItem>
+        <categoryId>org.eclipse.m2e.discovery.category.scm</categoryId>
+        <description>Subversive (3.0+) SVN Integration for the M2E Project</description>
+        <m2e-versions>1.6</m2e-versions>
+        <groupId>extras</groupId>
+        <id>org.eclipse.m2e.discovery.lifecyclemapping.m2e-subversive</id>
+        <kind>extras</kind>
+        <license>Eclipse Public License - v1.0</license>
+        <name>m2e-subversive</name>
+        <provider>Eclipse.org</provider>
+        <p2>
+            <repositoryUrl>http://download.eclipse.org/technology/subversive/3.0/update-site/</repositoryUrl>
+            <iuId>org.eclipse.team.svn.m2e.feature.group</iuId>
+      </p2>
+      <overview>
+        <summary>Integration with M2E http://www.eclipse.org/m2e Installation is possible only if M2E is already installed or installed in one step with Eclipse Subversive.</summary>
+        <url>http://www.eclipse.org/subversive/</url>
+      </overview>
+    </catalogItem>
 
     <catalogItem>
       <categoryId>org.eclipse.m2e.discovery.category.scm</categoryId>


### PR DESCRIPTION
Added Subversive connector (org.eclipse.team.svn.m2e.feature.group) for newer v3.0+ releases of Subversive which comes with its own M2E connector (see http://dev.eclipse.org/svnroot/technology/org.eclipse.subversive/trunk/org.eclipse.team.svn.m2e-feature/).

Discussion on mailing list: http://dev.eclipse.org/mhonarc/lists//m2e-users/msg05181.html

- Bindul